### PR TITLE
Be able to filter recipes by tags

### DIFF
--- a/frontend/src/containers/Listing/Listing.jsx
+++ b/frontend/src/containers/Listing/Listing.jsx
@@ -50,7 +50,7 @@ export default function Listing() {
         <div>
           {availableTags.map((tag) => (
             <span
-              className={`text-xs inline-block box-content py-1.5 px-4 mr-4 text-md text-slate-900 rounded-full whitespace-nowrap max-w-fit undefined hover:cursor-pointer
+              className={`text-xs inline-block box-content py-1.5 px-4 mr-4 text-md text-slate-900 rounded-full whitespace-nowrap max-w-fit hover:cursor-pointer
                               ${
                                 tagFilters.includes(tag)
                                   ? 'bg-amber-400'


### PR DESCRIPTION
> [MatterSpace PBI](https://matterstore.atlassian.net/browse/MS-112)

## This PR allows users to filter recipes by tags
Note: the position of the tags is a bit weird right now because of "Your Recipe Collection text", but I assume this is going to change once we add collections, so haven't considered it.

<img width="1257" alt="image" src="https://user-images.githubusercontent.com/14151679/195963601-54a3904d-7200-4678-9ac1-e39490fa4a9f.png">

## To test this PR please check the snapshot
